### PR TITLE
Add domain enrichment script for Ahrefs and Moz metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Moneycheck Domain Enrichment
+
+This repository contains a Python CLI that enriches domain lists with Ahrefs and Moz metrics.
+
+## Requirements
+- Python 3.10+
+- Dependencies from `requirements.txt` (`pip install -r requirements.txt`)
+- API credentials in environment variables or a local `.env`:
+  - `AHREFS_API_TOKEN`
+  - `MOZ_ACCESS_ID`
+  - `MOZ_SECRET_KEY`
+
+## Running the CLI
+The main entry point is `src/enrich_domains.py`.
+
+```bash
+python -m src.enrich_domains \
+  --input domains.xlsx \
+  --output domains_with_metrics.xlsx \
+  --domain-column domain
+```
+
+Supported options:
+- `--input` (required): path to CSV/XLSX with a `domain` column (or use `--domain-column`).
+- `--output`: explicit output path; defaults to adding `_with_metrics` to the input name.
+- `--domain-column`: column containing domains (default: `domain`).
+- `--sheet`: sheet name for XLSX input.
+- `--delimiter`: CSV delimiter (default `,`).
+- `--limit`: maximum number of rows to process (for quick tests).
+
+During execution the script normalizes each domain, caches duplicate lookups, and logs progress plus any API warnings.
+
+## Why is `index.php` empty?
+`index.php` is only a placeholder; the project logic lives in the Python CLI under `src/`. The PHP file remains empty because there is no web front-end in this repository. If you need a PHP entry point later, you can repurpose or remove it without affecting the current workflow.

--- a/index.php
+++ b/index.php
@@ -1,1 +1,3 @@
-
+<?php
+// Placeholder file: the project currently exposes only a Python CLI in src/enrich_domains.py.
+// Add web-facing functionality here if a PHP front end is introduced later.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+pandas
+openpyxl

--- a/src/ahrefs_client.py
+++ b/src/ahrefs_client.py
@@ -1,0 +1,83 @@
+import logging
+import time
+from typing import Dict, Optional
+
+import requests
+from requests import Response
+
+from .config import AhrefsConfig
+
+
+log = logging.getLogger(__name__)
+
+
+class AhrefsClient:
+    def __init__(self, config: AhrefsConfig):
+        self.config = config
+
+    def _request_with_retry(self, params: Dict[str, str]) -> Optional[Response]:
+        delay = self.config.delay_seconds
+        for attempt in range(self.config.max_retries + 1):
+            try:
+                response = requests.get(self.config.base_url, params=params, timeout=15)
+                if response.status_code == 429 or response.status_code >= 500:
+                    log.warning(
+                        "Ahrefs temporary error (status %s): %s", response.status_code, response.text
+                    )
+                    if attempt < self.config.max_retries:
+                        time.sleep(delay)
+                        delay *= self.config.backoff_factor
+                        continue
+                response.raise_for_status()
+                return response
+            except requests.RequestException as exc:
+                log.warning("Ahrefs request failed: %s", exc)
+                if attempt < self.config.max_retries:
+                    time.sleep(delay)
+                    delay *= self.config.backoff_factor
+        return None
+
+    def get_metrics(self, domain: str) -> Dict[str, Optional[float]]:
+        """Return DR, UR (as PR surrogate) and organic keywords count for a domain."""
+        params = {
+            "token": self.config.api_token,
+            "from": "domain_rating",
+            "target": domain,
+            "mode": "domain",
+            "output": "json",
+        }
+
+        metrics = {"dr": None, "pr": None, "keywords": None}
+
+        response = self._request_with_retry(params)
+        time.sleep(self.config.delay_seconds)
+        if response is None:
+            return metrics
+
+        try:
+            payload = response.json()
+            if payload.get("domain_rating") is not None:
+                metrics["dr"] = float(payload["domain_rating"])
+            if payload.get("url_rating") is not None:
+                metrics["pr"] = float(payload["url_rating"])
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Ahrefs JSON parsing failed for %s: %s", domain, exc)
+
+        # fetch organic keywords count
+        keywords_params = {
+            "token": self.config.api_token,
+            "from": "positions_metrics",
+            "target": domain,
+            "mode": "domain",
+            "output": "json",
+        }
+        response_kw = self._request_with_retry(keywords_params)
+        if response_kw is not None:
+            try:
+                payload = response_kw.json()
+                if isinstance(payload, dict) and "organic_keywords" in payload:
+                    metrics["keywords"] = int(payload["organic_keywords"])
+            except Exception as exc:  # noqa: BLE001
+                log.warning("Ahrefs keyword JSON parsing failed for %s: %s", domain, exc)
+
+        return metrics

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,82 @@
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+def _load_dotenv_if_present(path: str = ".env") -> None:
+    if not os.path.exists(path):
+        return
+
+    try:
+        with open(path, "r", encoding="utf-8") as env_file:
+            for line in env_file:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if "=" not in stripped:
+                    continue
+                key, value = stripped.split("=", 1)
+                os.environ.setdefault(key, value)
+    except OSError:
+        return
+
+
+_load_dotenv_if_present()
+
+
+@dataclass
+class AhrefsConfig:
+    api_token: str
+    base_url: str = "https://apiv2.ahrefs.com"
+    delay_seconds: float = 0.5
+    max_retries: int = 2
+    backoff_factor: float = 1.5
+
+
+@dataclass
+class MozConfig:
+    access_id: str
+    secret_key: str
+    base_url: str = "https://lsapi.seomoz.com/v2/url_metrics"
+    delay_seconds: float = 0.5
+    max_retries: int = 2
+    backoff_factor: float = 1.5
+
+
+@dataclass
+class DomainConfig:
+    strip_www: bool = True
+
+
+@dataclass
+class AppConfig:
+    ahrefs: Optional[AhrefsConfig]
+    moz: Optional[MozConfig]
+    domain: DomainConfig = DomainConfig()
+
+
+class MissingConfigError(RuntimeError):
+    """Raised when required API configuration is absent."""
+
+
+THRESHOLD_ENV_WARNING = (
+    "Environment variables for Ahrefs or Moz are not fully set. "
+    "Requests to the respective APIs will be skipped."
+)
+
+
+def load_config() -> AppConfig:
+    ahrefs_token = os.getenv("AHREFS_API_TOKEN")
+    moz_access_id = os.getenv("MOZ_ACCESS_ID")
+    moz_secret_key = os.getenv("MOZ_SECRET_KEY")
+
+    ahrefs_config = None
+    moz_config = None
+
+    if ahrefs_token:
+        ahrefs_config = AhrefsConfig(api_token=ahrefs_token)
+
+    if moz_access_id and moz_secret_key:
+        moz_config = MozConfig(access_id=moz_access_id, secret_key=moz_secret_key)
+
+    return AppConfig(ahrefs=ahrefs_config, moz=moz_config)

--- a/src/domain_normalizer.py
+++ b/src/domain_normalizer.py
@@ -1,0 +1,35 @@
+import re
+from urllib.parse import urlparse
+
+from .config import DomainConfig
+
+
+DOMAIN_PATTERN = re.compile(r"^[a-z0-9.-]+$")
+
+
+def normalize_domain(raw: str, config: DomainConfig) -> str:
+    """Normalize a domain string for consistent API calls."""
+    if not raw:
+        return ""
+
+    candidate = raw.strip().lower()
+
+    if "//" in candidate:
+        parsed = urlparse(candidate)
+        candidate = parsed.netloc or parsed.path
+    else:
+        # Prepend scheme for parsing paths correctly
+        parsed = urlparse(f"//{candidate}", scheme="http")
+        candidate = parsed.netloc
+
+    candidate = candidate.split("/")[0]
+
+    if config.strip_www and candidate.startswith("www."):
+        candidate = candidate[4:]
+
+    candidate = candidate.split(":")[0]
+
+    if not DOMAIN_PATTERN.match(candidate):
+        return ""
+
+    return candidate

--- a/src/enrich_domains.py
+++ b/src/enrich_domains.py
@@ -1,0 +1,131 @@
+import argparse
+import logging
+from typing import Dict, Optional
+
+import pandas as pd
+
+from .ahrefs_client import AhrefsClient
+from .config import THRESHOLD_ENV_WARNING, AppConfig, load_config
+from .domain_normalizer import normalize_domain
+from .file_io import build_output_path, read_input
+from .moz_client import MozClient
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger(__name__)
+
+AHREFS_DR = "Ahrefs_DR"
+AHREFS_PR = "Ahrefs_PR"
+AHREFS_KEYWORDS = "Ahrefs_Keywords"
+MOZ_DA = "Moz_DA"
+MOZ_PA = "Moz_PA"
+
+
+class MetricCache:
+    def __init__(self):
+        self.store: Dict[str, Dict[str, Optional[float]]] = {}
+
+    def get(self, domain: str) -> Optional[Dict[str, Optional[float]]]:
+        return self.store.get(domain)
+
+    def set(self, domain: str, metrics: Dict[str, Optional[float]]):
+        self.store[domain] = metrics
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Enrich domains with Ahrefs and Moz metrics")
+    parser.add_argument("--input", required=True, help="Path to input CSV/XLSX file")
+    parser.add_argument("--output", help="Path to output file")
+    parser.add_argument("--domain-column", default="domain", help="Column name with domains")
+    parser.add_argument("--sheet", help="Sheet name for XLSX files")
+    parser.add_argument("--delimiter", default=",", help="CSV delimiter")
+    parser.add_argument("--limit", type=int, help="Limit number of rows to process")
+    return parser.parse_args()
+
+
+def prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    for column in [AHREFS_DR, AHREFS_PR, AHREFS_KEYWORDS, MOZ_DA, MOZ_PA]:
+        if column not in df.columns:
+            df[column] = None
+    return df
+
+
+def process_domain(
+    domain: str,
+    config: AppConfig,
+    cache: MetricCache,
+    ahrefs_client: Optional[AhrefsClient],
+    moz_client: Optional[MozClient],
+) -> Dict[str, Optional[float]]:
+    cached = cache.get(domain)
+    if cached is not None:
+        return cached
+
+    metrics = {"dr": None, "pr": None, "keywords": None, "da": None, "pa": None}
+
+    if ahrefs_client:
+        ahrefs_metrics = ahrefs_client.get_metrics(domain)
+        metrics.update({"dr": ahrefs_metrics.get("dr"), "pr": ahrefs_metrics.get("pr"), "keywords": ahrefs_metrics.get("keywords")})
+    else:
+        log.warning("Skipping Ahrefs for %s: %s", domain, THRESHOLD_ENV_WARNING)
+
+    if moz_client:
+        moz_metrics = moz_client.get_metrics(domain)
+        metrics.update({"da": moz_metrics.get("da"), "pa": moz_metrics.get("pa")})
+    else:
+        log.warning("Skipping Moz for %s: %s", domain, THRESHOLD_ENV_WARNING)
+
+    cache.set(domain, metrics)
+    return metrics
+
+
+def main():
+    args = parse_args()
+    config = load_config()
+
+    df = read_input(
+        input_path=args.input,
+        domain_column=args.domain_column,
+        sheet_name=args.sheet,
+        delimiter=args.delimiter,
+        limit=args.limit,
+    )
+    df = prepare_dataframe(df)
+
+    ahrefs_client = AhrefsClient(config.ahrefs) if config.ahrefs else None
+    moz_client = MozClient(config.moz) if config.moz else None
+
+    cache = MetricCache()
+    total = len(df)
+    log.info("Found %s rows to process", total)
+
+    for index, raw_domain in enumerate(df[args.domain_column], start=1):
+        normalized = normalize_domain(raw_domain, config.domain)
+        if not normalized:
+            log.warning("Skipping invalid domain at row %s: %s", index, raw_domain)
+            continue
+
+        metrics = process_domain(normalized, config, cache, ahrefs_client, moz_client)
+
+        log.info("Processing %s/%s: %s", index, total, normalized)
+
+        df.loc[index - 1, AHREFS_DR] = metrics.get("dr")
+        df.loc[index - 1, AHREFS_PR] = metrics.get("pr")
+        df.loc[index - 1, AHREFS_KEYWORDS] = metrics.get("keywords")
+        df.loc[index - 1, MOZ_DA] = metrics.get("da")
+        df.loc[index - 1, MOZ_PA] = metrics.get("pa")
+
+    output_path = build_output_path(args.input, args.output)
+    _, ext = output_path.lower().rsplit('.', 1) if '.' in output_path else (output_path, '')
+    if ext == "csv":
+        df.to_csv(output_path, index=False, sep=args.delimiter)
+    elif ext in {"xlsx", "xls"}:
+        df.to_excel(output_path, index=False)
+    else:
+        df.to_excel(f"{output_path}.xlsx", index=False)
+        output_path = f"{output_path}.xlsx"
+
+    log.info("Completed. Output saved to %s", output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -1,0 +1,61 @@
+import os
+from typing import Optional
+
+import pandas as pd
+
+
+def _infer_output_path(input_path: str) -> str:
+    base, ext = os.path.splitext(input_path)
+    return f"{base}_with_metrics{ext}"
+
+
+def read_input(
+    input_path: str,
+    domain_column: str,
+    sheet_name: Optional[str] = None,
+    delimiter: str = ",",
+    limit: Optional[int] = None,
+) -> pd.DataFrame:
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    _, ext = os.path.splitext(input_path.lower())
+    if ext == ".csv":
+        df = pd.read_csv(input_path, delimiter=delimiter)
+    elif ext in {".xlsx", ".xls"}:
+        df = pd.read_excel(input_path, sheet_name=sheet_name)
+    else:
+        raise ValueError("Unsupported file extension. Use CSV or XLSX.")
+
+    if domain_column not in df.columns:
+        raise ValueError(f"Domain column '{domain_column}' not found in the file.")
+
+    if limit is not None:
+        df = df.head(limit)
+
+    return df
+
+
+def write_output(df: pd.DataFrame, output_path: Optional[str]) -> str:
+    path = output_path or _infer_output_path("output")
+    _, ext = os.path.splitext(path.lower())
+
+    if ext == ".csv":
+        df.to_csv(path, index=False)
+    elif ext in {".xlsx", ".xls"}:
+        df.to_excel(path, index=False)
+    else:
+        # default to xlsx if extension absent
+        if not ext:
+            path = f"{path}.xlsx"
+            df.to_excel(path, index=False)
+        else:
+            raise ValueError("Unsupported output extension. Use CSV or XLSX.")
+
+    return path
+
+
+def build_output_path(input_path: str, provided_output: Optional[str]) -> str:
+    if provided_output:
+        return provided_output
+    return _infer_output_path(input_path)

--- a/src/moz_client.py
+++ b/src/moz_client.py
@@ -1,0 +1,72 @@
+import base64
+import logging
+import time
+from typing import Dict, Optional
+
+import requests
+from requests import Response
+
+from .config import MozConfig
+
+
+log = logging.getLogger(__name__)
+
+
+class MozClient:
+    def __init__(self, config: MozConfig):
+        self.config = config
+        token = f"{config.access_id}:{config.secret_key}".encode()
+        self.auth_header = base64.b64encode(token).decode()
+
+    def _request_with_retry(self, payload: Dict[str, object]) -> Optional[Response]:
+        delay = self.config.delay_seconds
+        headers = {"Authorization": f"Basic {self.auth_header}"}
+
+        for attempt in range(self.config.max_retries + 1):
+            try:
+                response = requests.post(
+                    self.config.base_url,
+                    json=payload,
+                    headers=headers,
+                    timeout=15,
+                )
+                if response.status_code == 429 or response.status_code >= 500:
+                    log.warning(
+                        "Moz temporary error (status %s): %s", response.status_code, response.text
+                    )
+                    if attempt < self.config.max_retries:
+                        time.sleep(delay)
+                        delay *= self.config.backoff_factor
+                        continue
+                response.raise_for_status()
+                return response
+            except requests.RequestException as exc:
+                log.warning("Moz request failed: %s", exc)
+                if attempt < self.config.max_retries:
+                    time.sleep(delay)
+                    delay *= self.config.backoff_factor
+        return None
+
+    def get_metrics(self, domain: str) -> Dict[str, Optional[float]]:
+        payload = {"targets": [domain]}
+        metrics = {"da": None, "pa": None}
+
+        response = self._request_with_retry(payload)
+        time.sleep(self.config.delay_seconds)
+        if response is None:
+            return metrics
+
+        try:
+            data = response.json()
+            if isinstance(data, dict):
+                results = data.get("results") or []
+                if results:
+                    first = results[0]
+                    if "domain_authority" in first:
+                        metrics["da"] = float(first.get("domain_authority"))
+                    if "page_authority" in first:
+                        metrics["pa"] = float(first.get("page_authority"))
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Moz JSON parsing failed for %s: %s", domain, exc)
+
+        return metrics


### PR DESCRIPTION
## Summary
- add a command-line enrichment script that normalizes domains and fetches Ahrefs and Moz metrics with caching
- implement dedicated clients with retry/delay handling and environment-based configuration
- add supporting requirements file and gitignore entries

## Testing
- `pip install -r requirements.txt` (fails in container due to proxy restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1843f7bc832c8603da9c20640685)